### PR TITLE
v0.3.1 Fixed timestamp error in timezone calculation

### DIFF
--- a/example.htm
+++ b/example.htm
@@ -284,7 +284,7 @@
 			function getTimestamp ()
 			{
 				var d	= new Date ();
-				return Math.round (d.getTime () / 1000) + (d.getTimezoneOffset () * 3600);
+				return Math.round (d.getTime () / 1000) - (d.getTimezoneOffset () * 60);
 			}
 			
 			setInterval (function () {


### PR DESCRIPTION
Looks like the /example.htm had a miscalculation in its timezone math in getTimestamp().  In California now, a typical return from getTimezoneOffset() might be 420 (positive number) so the expected behavior is to *subtract* sixty times this number if you're looking for seconds.

This version appears to produce the expected results for someone who's *not* in the GMT timezone. 